### PR TITLE
suppression for IDE

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -356,5 +356,8 @@
                       default="checkstyle-xpath-suppressions.xml"/>
             <property name="optional" value="true"/>
         </module>
+        <module name="SuppressionFilter">
+            <property name="file" value="https://raw.githubusercontent.com/trans-sdt/checkstyle/main/checkstyle-suppressions.xml"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
podpiałem link pod wyjątki w checkstyle tak aby IDE nie krzyczało w miejscach które nie powinno - Nie da się podpiąć pliku z wykluczeniami bezpośrednio w IDE więc to jest taki workaround ponieważ da się wpiąć plik z checkstyle który w sobie będzie miał już źródło wyjątków.